### PR TITLE
Add serviceaccounts & networkpolicies resources

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -93,8 +93,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {clusterrole}
 rules:
-- apiGroups: ["", "apps", "batch", "rbac.authorization.k8s.io"]
-  resources: ["pods", "namespaces", "services", "deployments", "jobs", "roles", "rolebindings", "nodes", "secrets", "serviceaccounts"]
+- apiGroups: ["", "apps", "batch", "rbac.authorization.k8s.io", "networking.k8s.io"]
+  resources: ["pods", "namespaces", "services", "deployments", "jobs", "roles", "rolebindings", "nodes", "secrets", "serviceaccounts", "networkpolicies"]
   verbs: ["get", "list", "create", "update", "patch", "watch", "delete", "deletecollection"]
 ---
 kind: ClusterRoleBinding

--- a/k8-definition/ctfd-deployment.yaml
+++ b/k8-definition/ctfd-deployment.yaml
@@ -47,8 +47,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ctf-clusterrole
 rules:
-- apiGroups: ["", "apps", "batch", "rbac.authorization.k8s.io"]
-  resources: ["pods", "namespaces", "services", "deployments", "jobs", "roles", "rolebindings", "nodes", "secrets"]
+- apiGroups: ["", "apps", "batch", "rbac.authorization.k8s.io", "networking.k8s.io"]
+  resources: ["pods", "namespaces", "services", "deployments", "jobs", "roles", "rolebindings", "nodes", "secrets", "serviceaccounts", "networkpolicies"]
   verbs: ["get", "list", "create", "update", "patch", "watch", "delete", "deletecollection"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
The "networkpolicies" resource needs to be added to the ctf-clusterrole otherwise the "deployXXXX" accounts won't get the role as the ctf-clusterrole doesn't have permission to it. Also added these to the ctfd-deployment.yaml.